### PR TITLE
fix: wire footer links to existing routes and remove unbuilt pages

### DIFF
--- a/src/app/components/shared/footer/footer.component.html
+++ b/src/app/components/shared/footer/footer.component.html
@@ -16,27 +16,15 @@
       <div class="sw-footer__col">
         <h4 class="sw-footer__col-heading">Company</h4>
         <ul class="sw-footer__col-list">
-          <li><a href="#" class="sw-footer__link">About</a></li>
-          <li><a href="#" class="sw-footer__link">Careers</a></li>
-          <li><a href="#" class="sw-footer__link">Contact</a></li>
+          <li><a routerLink="/about" class="sw-footer__link">About</a></li>
+          <li><a routerLink="/contact" class="sw-footer__link">Contact</a></li>
         </ul>
       </div>
 
       <div class="sw-footer__col">
         <h4 class="sw-footer__col-heading">Resources</h4>
         <ul class="sw-footer__col-list">
-          <li><a href="#" class="sw-footer__link">Blog</a></li>
-          <li><a href="#" class="sw-footer__link">Documentation</a></li>
-          <li><a href="#" class="sw-footer__link">Help Center</a></li>
-        </ul>
-      </div>
-
-      <div class="sw-footer__col">
-        <h4 class="sw-footer__col-heading">Legal</h4>
-        <ul class="sw-footer__col-list">
-          <li><a href="#" class="sw-footer__link">Privacy</a></li>
-          <li><a href="#" class="sw-footer__link">Terms</a></li>
-          <li><a href="#" class="sw-footer__link">Cookie Policy</a></li>
+          <li><a routerLink="/help" class="sw-footer__link">Help Center</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Replace all placeholder href="#" links with routerLink directives for /about, /contact, and /help. Remove Careers, Blog, Documentation, and the entire Legal column as no corresponding routes exist yet.